### PR TITLE
undo sorting in buildDomain()

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -16,7 +16,7 @@ import java.nio.file.Paths
  * language governing permissions and limitations under the License.
  */
 
-project(group: "com.inversoft.savant.plugin", name: "client-library", version: "0.4.3", licenses: ["ApacheV2_0"]) {
+project(group: "com.inversoft.savant.plugin", name: "client-library", version: "0.4.4", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       cache()

--- a/src/main/groovy/com/inversoft/savant/plugin/clientLibrary/ClientLibraryPlugin.groovy
+++ b/src/main/groovy/com/inversoft/savant/plugin/clientLibrary/ClientLibraryPlugin.groovy
@@ -143,13 +143,14 @@ class ClientLibraryPlugin extends BaseGroovyPlugin {
     if (settings.domainDirectory.toFile().exists()) {
       def domainFiles = []
       settings.domainDirectory.eachFile(FileType.FILES) { domainFiles << it }
-      domainFiles.sort Comparator.comparing { f -> f.toFile().name.split("\\.")[-2] } // sort by class name
       domainFiles.each { f ->
         root['domain'] << jsonSlurper.parse(f.toFile())
       }
     }
 
     root.domain.each { domain ->
+      // TODO - this overwrites previous entries when we reuse names for static inner classes
+      // E.g., LambdaConfiguration
       root.type_to_package.put(domain.type, domain.packageName)
     }
 


### PR DESCRIPTION
### Issue:
- https://linear.app/fusionauth/issue/ENG-2184/client-code-generation-is-non-deterministic

### Problem:
Previous PR that sorted domain objects introduced extraneous imports (`using`) in the netcore client. This is from the sorting that was also added to the `buildDomain()` function. Turns out the sorting in `buildClient()` is the only one needed to make the go client and typescript client generation stable. 

### Solution:
Remove the extraneous sorting that introduces issues. Added comment about clobbering that happens with type to package name mapping.

### Linked PR:
- https://github.com/inversoft/client-library-plugin/pull/3

### Reviewer Notes:
The netcore client generation freemarker has a fair bit of handcrafted logic in it to work. Perhaps this can be refactored, but I didn't want to go down this rabbit hole. Part of the issue is that we reuse names for static inner classes like `LambdaConfiguration`